### PR TITLE
align with naming convention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Philip Schmid <docker@ins.hsr.ch>"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# network-ninja - A network TShoot Docker Image
+# ninja - A network TShoot Docker Image
 A Docker image which contains multiple helpful network troubleshooting packages. We use this image inside GNS3 labs.
 
 Installed packages:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  ninja:
+    image: hsrnetwork/ninja:latest
+    hostname: ninja.example.com
+    restart: unless-stopped


### PR DESCRIPTION
The naming of this image is inconsistent with common practice.
I would suggest renaming network-ninja to docker-ninja or simply ninja for short.

- [ ] Rename repository
- [ ] Rename container

I have also upgraded to the latest Ubuntu LTS release.