### PR TITLE
add wpa supplicant to installed tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     netcat \
     openssh-server \
     snmp \
-    snmpd
+    snmpd \
+    wpasupplicant
 
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
The WPA supplicant is needed to test IEEE 802.1X